### PR TITLE
Modifica campo observation para não requerido #149

### DIFF
--- a/intranet/access/forms/forms.py
+++ b/intranet/access/forms/forms.py
@@ -21,7 +21,7 @@ class AccessForm(forms.Form):
     doc_type = forms.ChoiceField(label='Documento', choices=DOCS)
     doc_number = forms.CharField(label='Número do documento')
     answerable = forms.ChoiceField(label='Responsável', choices=ANSWERABLE)
-    observation = forms.CharField(label='Observação', widget=forms.Textarea(attrs={'class': 'materialize-textarea'}))
+    observation = forms.CharField(label='Observação', widget=forms.Textarea(attrs={'class': 'materialize-textarea'}), required=False)
 
     def clean(self):
         cleaned_data = super().clean()

--- a/intranet/access/tests/test_access_form.py
+++ b/intranet/access/tests/test_access_form.py
@@ -96,6 +96,11 @@ class AccessFormValidationTest(TestCase):
         form = self.make_form(doc_type='CPF', doc_number='46792039004')
         self.assertIn('doc_number', form.cleaned_data)
 
+    def test_observation_is_not_required(self):
+        """Observation field should not be required"""
+        form = self.make_form()
+        self.assertFalse(form.fields['observation'].required)
+
     def assertFormMessage(self, form, field, msg):
         errors = form.errors.as_data()
         error_list = errors[field]


### PR DESCRIPTION
No formulário AccessForm, o attributo observation foi alterado
com a propriedade required igual a False. Este campo do formulário
não requer o prenchimento obrigatório