### PR TITLE
Previne a criação de acessos duplicados #152

### DIFF
--- a/intranet/access/tests/test_view_access.py
+++ b/intranet/access/tests/test_view_access.py
@@ -113,6 +113,11 @@ class TestAccessNewPostValid(TestCase):
         count = Access.objects.filter(weekdays="['0', '2']").count()
         self.assertEqual(1, count)
 
+    def test_update_or_create(self):
+        """If an access object already exists, it should be updated"""
+        self.send_post()
+        self.assertEqual(1, Access.objects.count())
+
     def send_post(self, **kwargs):
         default_data = {'enable': True, 'period_to': '2019-12-20', 'period_from': '2019-12-12',
                         'time_to': '13:13', 'time_from': '20:20', 'institution': 'IAG',

--- a/intranet/access/views.py
+++ b/intranet/access/views.py
@@ -35,7 +35,8 @@ def create(request):
         messages.error(request, message)
         return render(request, 'access/access_form.html', {'form': form})
 
-    access = Access.objects.create(**form.cleaned_data)
+    doc_number = {'doc_number': form.cleaned_data.get('doc_number')}
+    access, created = Access.objects.update_or_create(defaults=form.cleaned_data, **doc_number)
     request.user.access_set.add(access)
 
     _send_email({'access': access})


### PR DESCRIPTION
Quando um acesso é solicitado com um número de documento de um acesso
já existente, pe feita a atualização do acesso já existente, evitando
a criação de mais de uma solicitação de acesso com o mesmo número
de documento